### PR TITLE
Support LE ClusterIssuer / rename extra vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**2.1.0+1.1.0**
+
+- the role now supports to install "ClusterIssuer" for Let's Encrypt staging and production (see "cert_manager_le_clusterissuer_options" variable)
+
 **2.0.0+1.1.0**
 
 - rename extra vars `cm_(install|upgrade|delete)=true` to `action=(install|upgrade|delete)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**2.0.0+1.1.0**
+
+- rename extra vars `cm_(install|upgrade|delete)=true` to `action=(install|upgrade|delete)`
+
 **1.0.0+1.1.0**
 
 - initial commit for cert-manager v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 Changelog
 ---------
 
-**2.1.0+1.1.0**
-
-- the role now supports to install "ClusterIssuer" for Let's Encrypt staging and production (see "cert_manager_le_clusterissuer_options" variable)
-
 **2.0.0+1.1.0**
 
 - rename extra vars `cm_(install|upgrade|delete)=true` to `action=(install|upgrade|delete)`
+- the role now supports to install "ClusterIssuer" for Let's Encrypt staging and production (see "cert_manager_le_clusterissuer_options" variable)
 
 **1.0.0+1.1.0**
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ One of the final tasks is called `TASK [githubixx.cert-manager-kubernetes : Outp
 If the rendered output contains everything you need, the role can be installed which finally deploys cert-manager (still assuming the playbook file is called `k8s.yml` - if not please adjust accordingly):
 
 ```bash
-ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars cm_action=install k8s.yml
+ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars action=install k8s.yml
 ```
 
 To check if everything was deployed use the usual `kubectl` commands like `kubectl -n <cert_manager_namespace> get pods -o wide`. Before the playbook finishes it waits for the first `cert-manager-webhooks` pod to become ready.
@@ -74,13 +74,13 @@ To check if everything was deployed use the usual `kubectl` commands like `kubec
 Sooner or later there will be a new cert-manager version and you want to upgrade. Before doing the upgrade read the cert-manager [upgrade guide](https://cert-manager.io/docs/installation/upgrading/) carefully! If everything is in place you basically only need to change `cert_manager_chart_version` variable e.g. from `v1.1.0` to `v1.2.0` to upgrade from `v1.1.0` to `v1.2.0`. So to do the update run
 
 ```bash
-ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars cm_action=upgrade k8s.yml
+ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars action=upgrade k8s.yml
 ```
 
 And finally if you want to get rid of cert-manager you can delete all resources (this of course deletes EVERYTHING cert-manager related and this might also include certificates and secrets cert-manager already created - so be careful!):
 
 ```bash
-ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars cm_action=delete k8s.yml
+ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars action=delete k8s.yml
 ```
 
 TODO

--- a/README.md
+++ b/README.md
@@ -46,6 +46,38 @@ cert_manager_namespace: "cert-manager"
 # installed custom resources to be DELETED.
 cert_manager_values:
   - installCRDs=true
+
+# To install "ClusterIssuer" for Let's Encrypt (LE) "cert_manager_le_clusterissuer_options"
+# needs to be defined. The variable contains a list of hashes and can be defined
+# in "group_vars/all.yml" e.g.
+#
+# name:   Defines the name of the "ClusterIssuer"
+# email:  Use a valid e-mail address to be alerted by LE in case a certificate
+#         expires
+# server: Hostname part of the LE URL
+# private_key_secret_ref_name:  Name of the secret which stores the private key
+# solvers_http01_ingress_class: Value of "kubernetes.io/ingress.class" annotation.
+#                               Depends on you ingress controller. Common values
+#                               are "traefik" for Traefik or "nginx" for nginx.
+#
+# Besides "email" the following values can be used as is and will create valid
+# "ClusterIssuer" for Let's Encrypt staging and production. Only "email" needs
+# to be adjusted if Traefik is used as ingress controller. For other ingress
+# controllers "solvers_http01_ingress_class" needs to be adjusted too. Currently
+# only "ClusterIssuer" and "http01" solver is implemented. For definition also
+# see "tasks/install-issuer.yml".
+#
+# cert_manager_le_clusterissuer_options:
+#   - name: letsencrypt-prod
+#     email: insert@your-e-mail-address.here
+#     server: acme-v02
+#     private_key_secret_ref_name: letsencrypt-account-key
+#     solvers_http01_ingress_class: "traefik"
+#   - name: letsencrypt-staging
+#     email: insert@your-e-mail-address.here
+#     server: acme-staging-v02
+#     private_key_secret_ref_name: letsencrypt-staging-account-key
+#     solvers_http01_ingress_class: "traefik"
 ```
 
 Usage
@@ -86,7 +118,6 @@ ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars action=delete 
 TODO
 ----
 
-- add possibility to manage cert-manager resources like `(Cluster)Issuer` and `Certificate` esp. for ACME (Let's Encrypt)
 - add option to install cert-manager plugin for `kubectl`
 - add more error checks
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage
 
 First check if you want to change any of the default values in `default/main.yml`. As usual those values can be overridden in `host_vars` or `group_vars`. Normally there is no need to change that much. Besides the `cert_manager_chart_version` you might want do add a few options to `cert_manager_values`. It contains the configurable parameters of the cert-manager Helm chart. The list is submitted "as is" to `helm` binary for `template`, `install` or `upgrade` commands.
 
-The default action is to just render the Kubernetes resources YAML file after replacing all Jinja2 variables and stuff like that (that means not specifying any value via `--extra-vars cm_action=...` to `ansible-playbook`). In the `Example Playbook` section below there is an `Example 2 (assign tag to role)`. The role `githubixx.cert_manager_kubernetes` has a tag `role-cert-manager-kubernetes` assigned.
+The default action is to just render the Kubernetes resources YAML file after replacing all Jinja2 variables and stuff like that (that means not specifying any value via `--extra-vars action=...` to `ansible-playbook`). In the `Example Playbook` section below there is an `Example 2 (assign tag to role)`. The role `githubixx.cert_manager_kubernetes` has a tag `role-cert-manager-kubernetes` assigned.
 
 So to render the YAML files the WOULD be applied (nothing will be installed at this time) and the playbook is called `k8s.yml` execute the following command:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,35 @@ cert_manager_namespace: "cert-manager"
 # installed custom resources to be DELETED
 cert_manager_values:
   - installCRDs=true
+
+# To install "ClusterIssuer" for Let's Encrypt (LE) "cert_manager_le_clusterissuer_options"
+# needs to be defined. The variable contains a list of hashes and can be defined
+# in "group_vars/all.yml" e.g.
+#
+# name:   Defines the name of the "ClusterIssuer"
+# email:  Use a valid e-mail address to be alerted by LE in case a certificate
+#         expires
+# server: Hostname part of the LE URL
+# private_key_secret_ref_name:  Name of the secret which stores the private key
+# solvers_http01_ingress_class: Value of "kubernetes.io/ingress.class" annotation.
+#                               Depends on you ingress controller. Common values
+#                               are "traefik" for Traefik or "nginx" for nginx.
+#
+# Besides "email" the following values can be used as is and will create valid
+# "ClusterIssuer" for Let's Encrypt staging and production. Only "email" needs
+# to be adjusted if Traefik is used as ingress controller. For other ingress
+# controllers "solvers_http01_ingress_class" needs to be adjusted too. Currently
+# only "ClusterIssuer" and "http01" solver is implemented. For definition also
+# see "tasks/install-issuer.yml".
+#
+# cert_manager_le_clusterissuer_options:
+#   - name: letsencrypt-prod
+#     email: insert@your-e-mail-address.here
+#     server: acme-v02
+#     private_key_secret_ref_name: letsencrypt-account-key
+#     solvers_http01_ingress_class: "traefik"
+#   - name: letsencrypt-staging
+#     email: insert@your-e-mail-address.here
+#     server: acme-staging-v02
+#     private_key_secret_ref_name: letsencrypt-staging-account-key
+#     solvers_http01_ingress_class: "traefik"

--- a/tasks/delete-issuer.yml
+++ b/tasks/delete-issuer.yml
@@ -1,0 +1,10 @@
+---
+- name: Delete Let's Encrypt ClusterIssuer
+  k8s:
+    state: absent
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      name: "{{ item.name }}"
+  loop: "{{ cert_manager_le_clusterissuer_options }}"
+  when: cert_manager_le_clusterissuer_options is defined

--- a/tasks/install-issuer.yml
+++ b/tasks/install-issuer.yml
@@ -1,0 +1,21 @@
+---
+- name: Install Let's Encrypt ClusterIssuer
+  k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: "{{ item.name }}"
+      spec:
+        acme:
+          email: "{{ item.email }}"
+          server: "https://{{ item.server }}.api.letsencrypt.org/directory"
+          privateKeySecretRef:
+            name: "{{ item.private_key_secret_ref_name }}"
+          solvers:
+            - http01:
+                ingress:
+                  class: "{{ item.solvers_http01_ingress_class }}"
+  loop: "{{ cert_manager_le_clusterissuer_options }}"
+  when: cert_manager_le_clusterissuer_options is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,5 +40,23 @@
     - action is defined
     - '"delete" in action'
 
+- name: Set action to install issuer
+  set_fact:
+    deploy_action: "install-issuer"
+  delegate_to: 127.0.0.1
+  run_once: True
+  when:
+    - action is defined
+    - '"install-issuer" in action'
+
+- name: Set action to delete issuer
+  set_fact:
+    deploy_action: "delete-issuer"
+  delegate_to: 127.0.0.1
+  run_once: True
+  when:
+    - action is defined
+    - '"delete-issuer" in action'
+
 - name: Include tasks to execute requested action
   include_tasks: "tasks/{{ deploy_action|lower }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,8 @@
   delegate_to: 127.0.0.1
   run_once: True
   when:
-    - cm_action is defined
-    - '"install" in cm_action'
+    - action is defined
+    - '"install" in action'
 
 - name: Set action to upgrade via Helm
   set_fact:
@@ -28,8 +28,8 @@
   delegate_to: 127.0.0.1
   run_once: True
   when:
-    - cm_action is defined
-    - '"upgrade" in cm_action'
+    - action is defined
+    - '"upgrade" in action'
 
 - name: Set action to delete via Helm
   set_fact:
@@ -37,8 +37,8 @@
   delegate_to: 127.0.0.1
   run_once: True
   when:
-    - cm_action is defined
-    - '"delete" in cm_action'
+    - action is defined
+    - '"delete" in action'
 
 - name: Include tasks to execute requested action
   include_tasks: "tasks/{{ deploy_action|lower }}.yml"


### PR DESCRIPTION
- rename extra vars `cm_(install|upgrade|delete)=true` to `action=(install|upgrade|delete)`
- the role now supports to install "ClusterIssuer" for Let's Encrypt staging and production (see "cert_manager_le_clusterissuer_options" variable)