### PR TITLE
update to cert-manager v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+**3.0.0+1.5.3**
+
+- update cert-manager to `v1.5.3`
+- add label `cert-manager.io/disable-validation: "true"` to cert-manager namespace
+- add two new options to `cert_manager_values`: `global.leaderElection.namespace="{{ cert_manager_namespace }}"` and `startupapicheck.enabled=false`
+
 **2.2.0+1.5.1**
 
 - update cert-manager to `v1.5.1`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs [cert-manager](https://cert-manager.io/) on a Kuberne
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `2.2.0+1.5.1` means this is release `2.2.0` of this role and it contains cert-manager chart version `1.5.1`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `2.2.1+1.5.3` means this is release `2.2.1` of this role and it contains cert-manager chart version `1.5.3`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
 
 Requirements
 ------------
@@ -20,7 +20,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cert_manager_chart_version: "v1.5.1"
+cert_manager_chart_version: "v1.5.3"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"
@@ -46,6 +46,8 @@ cert_manager_namespace: "cert-manager"
 # installed custom resources to be DELETED.
 cert_manager_values:
   - installCRDs=true
+  - global.leaderElection.namespace="{{ cert_manager_namespace }}"
+  - startupapicheck.enabled=false
 
 # To install "ClusterIssuer" for Let's Encrypt (LE) "cert_manager_le_clusterissuer_options"
 # needs to be defined. The variable contains a list of hashes and can be defined
@@ -178,8 +180,8 @@ ansible-playbook --tags=role-cert-manager-kubernetes --extra-vars action=delete-
 TODO
 ----
 
-- add option to install cert-manager plugin for `kubectl`
-- add more error checks
+[] add option to install cert-manager plugin for `kubectl`
+[] add more error checks
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-cert_manager_chart_version: "v1.5.1"
+cert_manager_chart_version: "v1.5.3"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"
@@ -26,6 +26,8 @@ cert_manager_namespace: "cert-manager"
 # installed custom resources to be DELETED
 cert_manager_values:
   - installCRDs=true
+  - global.leaderElection.namespace="{{ cert_manager_namespace }}"
+  - startupapicheck.enabled=false
 
 # To install "ClusterIssuer" for Let's Encrypt (LE) "cert_manager_le_clusterissuer_options"
 # needs to be defined. The variable contains a list of hashes and can be defined

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -1,10 +1,14 @@
 ---
 - name: Ensure namespace
   k8s:
-    name: "{{ cert_manager_namespace }}"
-    api_version: v1
-    kind: Namespace
     state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ cert_manager_namespace }}"
+        labels:
+          cert-manager.io/disable-validation: "true"
   delegate_to: 127.0.0.1
   run_once: True
 


### PR DESCRIPTION
- update cert-manager to `v1.5.3`
- add label `cert-manager.io/disable-validation: "true"` to cert-manager namespace
- add two new options to `cert_manager_values`: `global.leaderElection.namespace="{{ cert_manager_namespace }}"` and `startupapicheck.enabled=false`