### PR TITLE
use release tag 6.0.0+1.7.1 instead of 5.1.0+1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-**5.1.0+1.7.1**
+**6.0.0+1.7.1**
 
 - update cert-manager to `v1.7.1` (**NOTE**: Please also read [cert-manager release notes for v1.7.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.7.0) as this release removes deprecated APIs e.g. cert-manager API versions `v1alpha2`, `v1alpha3`, and `v1beta1`. If you use `v1` already then the upgrade shouldn't be much of a problem.)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs [cert-manager](https://cert-manager.io/) on a Kuberne
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `5.1.0+1.7.1` means this is release `5.1.0` of this role and it contains cert-manager chart version `1.7.1`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `6.0.0+1.7.1` means this is release `6.0.0` of this role and it contains cert-manager chart version `1.7.1`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
 
 Requirements
 ------------


### PR DESCRIPTION
- As `cert-manager` `v1.7.1` is a breaking change I decided to not use version 5.1.0 for this release but increasing it to 6.0.0 to make sure that this might be a breaking change for some people. ATM `cert-manager doesn't follow semantic versioning. So upgrading from `cert-manager` `v1.6.x` to `v1.7.x` is basically a major release upgrade.