### PR TITLE
8.0.0+1.11.0

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+extends: default
+
+rules:
+  line-length:
+    max: 160
+    level: warning
+
+  comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **8.0.0+1.11.0**
 
 - update cert-manager to `v1.11.0`
+- add `.yamlint`
+- Avoid using free-form when calling module actions (ansible.builtin.set_fact)
 
 **7.3.1+1.10.1**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**8.0.0+1.11.0**
+
+- update cert-manager to `v1.11.0`
+
 **7.3.1+1.10.1**
 
 - update cert-manager to `v1.10.1`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cert_manager_chart_version: "v1.10.1"
+cert_manager_chart_version: "v1.11.0"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Example Playbook
 Example 1 (without role tag):
 
 ```yaml
+---
 - hosts: cert_manager
   roles:
     - githubixx.cert_manager_kubernetes
@@ -218,6 +219,7 @@ Example 1 (without role tag):
 Example 2 (assign tag to role):
 
 ```yaml
+---
 -
   hosts: cert_manager
   roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-cert_manager_chart_version: "v1.10.1"
+cert_manager_chart_version: "v1.11.0"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,7 +5,7 @@
 
 - name: Create values
   ansible.builtin.set_fact:
-    cert_manager_values_rendered="{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
+    cert_manager_values_rendered: "{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
 
 - name: Install release
   ansible.builtin.shell:

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -5,7 +5,7 @@
 
 - name: Create values
   ansible.builtin.set_fact:
-    cert_manager_values_rendered="{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
+    cert_manager_values_rendered: "{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
 
 - name: Render template
   ansible.builtin.shell:

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -5,7 +5,7 @@
 
 - name: Create values
   ansible.builtin.set_fact:
-    cert_manager_values_rendered="{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
+    cert_manager_values_rendered: "{% for option in cert_manager_values %}--set {{ option }} {% endfor %}"
 
 - name: Upgrade release
   ansible.builtin.shell:


### PR DESCRIPTION
- update cert-manager to `v1.11.0`
- add `.yamlint`
- Avoid using free-form when calling module actions (ansible.builtin.set_fact)