### PR TITLE
update cert-manager to v1.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+**9.0.0+1.12.6**
+
+Please read `cert-manager` `v1.12` [changelog](https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/) before upgrading!
+
+- update cert-manager to `v1.12.6`
+
 **8.0.1+1.11.1**
 
 - update cert-manager to `v1.11.1`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cert_manager_chart_version: "v1.11.1"
+cert_manager_chart_version: "v1.12.6"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-cert_manager_chart_version: "v1.11.1"
+cert_manager_chart_version: "v1.12.6"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"


### PR DESCRIPTION
Please read `cert-manager` `v1.12` [changelog](https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/) before upgrading!

- update cert-manager to `v1.12.6`
