### PR TITLE
update cert-manager to v1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 Changelog
 ---------
 
+**10.0.0+1.13.2**
+
+Please read `cert-manager` `v1.13` [release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.13/) and [changelog](https://github.com/cert-manager/cert-manager/releases/tag/v1.13.0) before upgrading!
+
+**IMPORTANT NOTE**: If upgrading from a version below `v1.12`, upgrade to the latest `v1.12` release before upgrading to `v1.13`. Otherwise, some certificates may be unexpectedly re-issued.
+
+- update cert-manager to `v1.13.2`
+
 **9.0.0+1.12.6**
 
-Please read `cert-manager` `v1.12` [changelog](https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/) before upgrading!
+Please read `cert-manager` `v1.12` [release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/) before upgrading!
 
 - update cert-manager to `v1.12.6`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs [cert-manager](https://cert-manager.io/) on a Kuberne
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `7.0.0+1.9.1` means this is release `7.0.0` of this role and it contains cert-manager chart version `1.9.1`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `10.0.0+1.13.2` means this is release `10.0.0` of this role and it contains cert-manager chart version `1.13.2`. If the role itself changes `X.Y.Z` before `+` will increase. If the cert-manager chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific cert-manager release.
 
 Requirements
 ------------
@@ -25,7 +25,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cert_manager_chart_version: "v1.12.6"
+cert_manager_chart_version: "v1.13.2"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-cert_manager_chart_version: "v1.12.6"
+cert_manager_chart_version: "v1.13.2"
 
 # Helm release name
 cert_manager_release_name: "cert-manager"


### PR DESCRIPTION
Please read `cert-manager` `v1.13` [release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.13/) and [changelog](https://github.com/cert-manager/cert-manager/releases/tag/v1.13.0) before upgrading!

**IMPORTANT NOTE**: If upgrading from a version below `v1.12`, upgrade to the latest `v1.12` release before upgrading to `v1.13`. Otherwise, some certificates may be unexpectedly re-issued.

- update cert-manager to `v1.13.2`
